### PR TITLE
feat: tag Control Tower Lambdas with VantaNoAlert; switch to InfraHouseGovernance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,20 @@ cross-account roles into member accounts or calling AWS Organizations APIs.
 
 - **CloudWatch Log Retention Enforcement** -- A Lambda function that enforces log retention
   policies across all member accounts. It lists accounts via `organizations:ListAccounts`,
-  assumes the `InfraHouseLogRetention` role (provisioned in each member account by
-  [terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001)) across all
-  enabled regions, and sets retention on CloudWatch log groups matching configurable prefixes
-  (e.g., `aws-controltower` groups locked by Control Tower's mandatory SCP).
+  assumes the `InfraHouseGovernance` role (provisioned in each member account by
+  [terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001) >= 2.2.0)
+  across all governed regions, and sets retention on CloudWatch log groups matching
+  configurable prefixes.
+- **Vanta Exclusion Tagging on Log Groups** -- Tags Control Tower-managed log groups
+  (matching `vanta_exclude_prefixes`) with `VantaNoAlert=true`. Used for log groups where
+  retention cannot be changed to satisfy a Vanta test because the GRLOGGROUPPOLICY
+  guardrail blocks `logs:PutRetentionPolicy` for any principal other than
+  `AWSControlTowerExecution`.
+- **Vanta Exclusion Tagging on Lambda Functions** -- Tags AWS-managed Lambda functions
+  (matching `vanta_exclude_lambda_prefixes`, default `aws-controltower-`) with
+  `VantaNoAlert=true`. Used for functions such as `aws-controltower-NotificationForwarder`
+  whose error rate is AWS's operational responsibility and cannot be alarmed without
+  StackSet drift.
 - **Management Account Deployment** -- Designed to run from the management account where
   AWS Organizations APIs are available.
 - **ISO 27001 Compliance** -- Enforces 365-day log retention to meet ISO 27001 and SOC 2
@@ -98,8 +108,9 @@ Full documentation is available on
 | <a name="input_enforce_log_retention"></a> [enforce\_log\_retention](#input\_enforce\_log\_retention) | Enable the scheduled Lambda that enforces minimum CloudWatch<br/>log group retention across all organization accounts. | `bool` | `true` | no |
 | <a name="input_enforce_log_retention_excluded_accounts"></a> [enforce\_log\_retention\_excluded\_accounts](#input\_enforce\_log\_retention\_excluded\_accounts) | List of AWS account IDs to skip during log retention<br/>enforcement. Use this for accounts that are part of the<br/>organization but intentionally not managed by this module<br/>(e.g., accounts owned by external parties, sandbox accounts<br/>with no compliance requirement). Excluded accounts are<br/>skipped in addition to any account that is not enrolled in<br/>Control Tower. | `list(string)` | `[]` | no |
 | <a name="input_enforce_log_retention_prefixes"></a> [enforce\_log\_retention\_prefixes](#input\_enforce\_log\_retention\_prefixes) | Log group name prefixes to target for retention enforcement.<br/>Only log groups matching these prefixes will have their<br/>retention updated. Defaults to an empty list — log groups that<br/>belong to other InfraHouse modules (e.g., GuardDuty scan<br/>events in terraform-aws-iso27001) should declare their own<br/>retention at creation time rather than relying on this Lambda<br/>to correct it after the fact. Control Tower log groups are<br/>intentionally not included here either — the GRLOGGROUPPOLICY<br/>guardrail denies logs:PutRetentionPolicy on *aws-controltower*<br/>log groups for any principal other than<br/>AWSControlTowerExecution, so they are handled via<br/>vanta\_exclude\_prefixes instead. | `list(string)` | `[]` | no |
-| <a name="input_enforce_log_retention_role_name"></a> [enforce\_log\_retention\_role\_name](#input\_enforce\_log\_retention\_role\_name) | Name of the cross-account IAM role the Lambda assumes in each<br/>member account to enforce log retention. The role must exist in<br/>every scanned account and trust the management account root.<br/>Defaults to InfraHouseLogRetention, provisioned by<br/>terraform-aws-iso27001. | `string` | `"InfraHouseLogRetention"` | no |
+| <a name="input_enforce_log_retention_role_name"></a> [enforce\_log\_retention\_role\_name](#input\_enforce\_log\_retention\_role\_name) | Name of the cross-account IAM role the Lambda assumes in each<br/>member account. The role must exist in every scanned account<br/>and trust the management account root. Defaults to<br/>InfraHouseGovernance (provisioned by terraform-aws-iso27001<br/>>= 2.2.0), which carries permissions for both log-group<br/>retention/tagging and Lambda function tagging. The variable<br/>name retains the historical "log\_retention" prefix; the role<br/>is now the broader governance role and a future release will<br/>rename the variable accordingly. | `string` | `"InfraHouseGovernance"` | no |
 | <a name="input_enforce_log_retention_schedule"></a> [enforce\_log\_retention\_schedule](#input\_enforce\_log\_retention\_schedule) | EventBridge schedule expression for the log retention<br/>enforcement Lambda. | `string` | `"rate(1 day)"` | no |
+| <a name="input_vanta_exclude_lambda_prefixes"></a> [vanta\_exclude\_lambda\_prefixes](#input\_vanta\_exclude\_lambda\_prefixes) | Lambda function name prefixes to tag with VantaNoAlert=true,<br/>marking them out of scope for Vanta compliance tests. Use this<br/>for Lambdas where Vanta findings (e.g., "Serverless function<br/>error rate monitored (AWS)") cannot be remediated because the<br/>Lambda is managed by AWS itself — Control Tower deploys<br/>aws-controltower-NotificationForwarder into every governed<br/>account/region and we cannot add CloudWatch alarms without<br/>StackSet drift. Vanta honors the VantaNoAlert tag continuously<br/>via its AWS integration. Applying is idempotent — already-<br/>tagged functions are skipped. | `list(string)` | <pre>[<br/>  "aws-controltower-"<br/>]</pre> | no |
 | <a name="input_vanta_exclude_prefixes"></a> [vanta\_exclude\_prefixes](#input\_vanta\_exclude\_prefixes) | Log group name prefixes to tag with VantaNoAlert=true, marking<br/>them out of scope for Vanta compliance tests. Use this for log<br/>groups where retention cannot be changed to satisfy a Vanta<br/>test (e.g., Control Tower managed log groups blocked by the<br/>GRLOGGROUPPOLICY SCP). Vanta honors the VantaNoAlert tag<br/>continuously via its AWS integration, so tagged resources are<br/>excluded from tests such as "Server logs retained for 365<br/>days (AWS)". Applying is idempotent — already-tagged groups<br/>are skipped. | `list(string)` | <pre>[<br/>  "/aws/lambda/aws-controltower-",<br/>  "StackSet-AWSControlTowerBP-"<br/>]</pre> | no |
 | <a name="input_vanta_exclude_tag_value"></a> [vanta\_exclude\_tag\_value](#input\_vanta\_exclude\_tag\_value) | Value to write for the VantaNoAlert tag on newly tagged log groups.<br/>Vanta only checks key presence, so the value can document the<br/>exclusion reason (e.g. "CT-managed, retention enforced by guardrail").<br/>Pre-existing values are never overwritten. | `string` | `"true"` | no |
 

--- a/cloudwatch_log_retention.tf
+++ b/cloudwatch_log_retention.tf
@@ -75,11 +75,13 @@ module "enforce_log_retention" {
   environment_variables = {
     RETENTION_DAYS            = tostring(var.cloudwatch_retention_days)
     LOG_GROUP_PREFIXES        = jsonencode(var.enforce_log_retention_prefixes)
-    VANTA_EXCLUDE_PREFIXES    = jsonencode(var.vanta_exclude_prefixes)
-    VANTA_EXCLUDE_TAG_VALUE   = var.vanta_exclude_tag_value
     ASSUME_ROLE_NAME          = var.enforce_log_retention_role_name
     CONTROL_TOWER_HOME_REGION = coalesce(var.control_tower_home_region, data.aws_region.current.region)
     EXCLUDED_ACCOUNTS         = jsonencode(var.enforce_log_retention_excluded_accounts)
+
+    VANTA_EXCLUDE_LAMBDA_PREFIXES = jsonencode(var.vanta_exclude_lambda_prefixes)
+    VANTA_EXCLUDE_PREFIXES        = jsonencode(var.vanta_exclude_prefixes)
+    VANTA_EXCLUDE_TAG_VALUE       = var.vanta_exclude_tag_value
   }
 
   additional_iam_policy_arns = [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,4 +90,58 @@ enforce_log_retention_schedule = "rate(6 hours)"
 enforce_log_retention_schedule = "cron(0 0 * * ? *)"
 ```
 
+### `enforce_log_retention_role_name`
 
+Name of the cross-account IAM role the Lambda assumes in each member account.
+The role must exist in every scanned account and trust the management account
+root.
+
+- **Type**: `string`
+- **Default**: `"InfraHouseGovernance"`
+
+The default targets the `InfraHouseGovernance` role provisioned by
+[terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001)
+>= 2.2.0, which carries permissions for both log-group retention/tagging and
+Lambda function tagging. The variable name retains the historical
+`log_retention` prefix for backward compatibility; a future major release will
+rename it.
+
+### `vanta_exclude_prefixes`
+
+Log group name prefixes to tag with `VantaNoAlert=true`. Used for log groups
+where retention cannot be changed to satisfy a Vanta test (e.g., Control Tower
+managed log groups blocked by `GRLOGGROUPPOLICY`).
+
+- **Type**: `list(string)`
+- **Default**:
+    ```hcl
+    [
+      "/aws/lambda/aws-controltower-",
+      "StackSet-AWSControlTowerBP-",
+    ]
+    ```
+
+### `vanta_exclude_lambda_prefixes`
+
+Lambda function name prefixes to tag with `VantaNoAlert=true`. Used for Lambdas
+where Vanta findings (e.g., "Serverless function error rate monitored (AWS)")
+cannot be remediated because the Lambda is managed by AWS itself —
+`aws-controltower-NotificationForwarder` is deployed into every governed
+account/region, and we cannot add CloudWatch alarms without StackSet drift.
+
+- **Type**: `list(string)`
+- **Default**:
+    ```hcl
+    [
+      "aws-controltower-",
+    ]
+    ```
+
+### `vanta_exclude_tag_value`
+
+Value to write for the `VantaNoAlert` tag on newly tagged resources. Vanta only
+checks key presence, so the value can document the exclusion reason.
+Pre-existing values are never overwritten.
+
+- **Type**: `string`
+- **Default**: `"true"`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,8 +11,15 @@
   `InfraHouseLogRetention`, which lacks the `lambda:ListFunctions` /
   `lambda:ListTags` / `lambda:TagResource` permissions required by
   the Vanta Lambda-tagging pass — the daily run will fail with
-  `AccessDeniedException`. To stay on `InfraHouseLogRetention` during
-  migration, override `enforce_log_retention_role_name`.
+  `AccessDeniedException` on every account/region. If you must
+  delay the iso27001 upgrade, you can pin to the old role by
+  setting **both** of the following — and the Vanta Lambda-tagging
+  pass will be disabled until you remove these overrides:
+
+    ```hcl
+    enforce_log_retention_role_name = "InfraHouseLogRetention"
+    vanta_exclude_lambda_prefixes   = []
+    ```
 
 ## First Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,13 +5,14 @@
 - **Terraform** >= 1.5
 - **AWS Provider** >= 6.0, < 7.0
 - Access to the **AWS Organizations management account**
-- The `InfraHouseLogRetention` role must exist in member accounts,
+- The `InfraHouseGovernance` role must exist in member accounts,
   provisioned by [terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001)
-  **>= 2.0.1**. Earlier versions of iso27001 grant only
-  `logs:PutRetentionPolicy` / `logs:DescribeLogGroups`, which is not
-  enough for the Vanta-exclusion tagging pass — the daily run will
-  fail with `AccessDeniedException` on `logs:ListTagsForResource` /
-  `logs:TagResource` / `logs:UntagResource`.
+  **>= 2.2.0**. Earlier versions of iso27001 provided only
+  `InfraHouseLogRetention`, which lacks the `lambda:ListFunctions` /
+  `lambda:ListTags` / `lambda:TagResource` permissions required by
+  the Vanta Lambda-tagging pass — the daily run will fail with
+  `AccessDeniedException`. To stay on `InfraHouseLogRetention` during
+  migration, override `enforce_log_retention_role_name`.
 
 ## First Deployment
 
@@ -38,7 +39,7 @@
     - A Lambda function (`enforce-log-retention`) that runs daily
     - An EventBridge rule to trigger the Lambda on schedule
     - An IAM role with permissions to list org accounts and assume
-      `InfraHouseLogRetention` in each member account
+      `InfraHouseGovernance` in each member account
     - CloudWatch alarms for Lambda errors (notifications sent to
       `alarm_emails`)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,9 +14,13 @@ This module provides a centralized deployment model for those tasks.
 
 - **CloudWatch Log Retention Enforcement** -- A scheduled Lambda that scans all organization
   member accounts and enforces minimum log retention on CloudWatch log groups created by AWS
-  services (Control Tower, GuardDuty, etc.). Works around Control Tower's mandatory SCP
-  (`GRLOGGROUPPOLICY`) by assuming the least-privilege `InfraHouseLogRetention` role
-  provisioned by [terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001).
+  services (Control Tower, GuardDuty, etc.). Assumes the least-privilege
+  `InfraHouseGovernance` role provisioned by
+  [terraform-aws-iso27001](https://github.com/infrahouse/terraform-aws-iso27001) >= 2.2.0.
+- **Vanta Exclusion Tagging** -- Tags Control Tower-managed log groups and AWS-managed
+  Lambda functions (e.g., `aws-controltower-NotificationForwarder`) with
+  `VantaNoAlert=true`, so Vanta excludes them from compliance tests we cannot remediate
+  (retention blocked by GRLOGGROUPPOLICY; CloudWatch alarms blocked by StackSet drift).
 - **ISO 27001 / SOC 2 Compliance** -- Enforces 365-day log retention by default.
 - **Multi-Region Support** -- Scans configurable regions across all active member accounts.
 

--- a/lambda/enforce_log_retention/handler.py
+++ b/lambda/enforce_log_retention/handler.py
@@ -1,22 +1,36 @@
 """Enforce CloudWatch log group compliance across the organization.
 
 Deployed in the management account, iterates over all organization
-member accounts and regions. Assumes the InfraHouseLogRetention role
-(provisioned by terraform-aws-iso27001 in each member account) to
-apply changes under least-privilege permissions.
+member accounts and regions. Assumes the InfraHouseGovernance role
+(provisioned by terraform-aws-iso27001 >= 2.2.0 in each member
+account) to apply changes under least-privilege permissions.
 
-Two passes run per account+region:
+Three passes run per account+region:
 
 1. Retention enforcement — for log groups matching
    ``LOG_GROUP_PREFIXES``, set ``retentionInDays`` to the configured
    value. Targets log groups implicitly created by AWS services
    (GuardDuty, ECS, etc.) and not managed by Terraform.
 
-2. Vanta exclusion tagging — for log groups matching
+2. Vanta exclusion tagging on log groups — for log groups matching
    ``VANTA_EXCLUDE_PREFIXES``, apply ``VantaNoAlert=true`` so Vanta
    marks them out of scope. Used for Control Tower managed log
    groups where the GRLOGGROUPPOLICY guardrail blocks retention
    changes for any principal other than AWSControlTowerExecution.
+
+3. Vanta exclusion tagging on Lambda functions — for Lambda
+   functions whose name matches ``VANTA_EXCLUDE_LAMBDA_PREFIXES``,
+   apply ``VantaNoAlert=true``. Used for AWS-managed functions
+   such as ``aws-controltower-NotificationForwarder`` where we
+   cannot add CloudWatch error alarms without StackSet drift, and
+   where error-rate monitoring is AWS's operational responsibility.
+
+This pass runs only against member accounts (the management
+account is never assumed into), so the orchestrator's own
+``enforce-log-retention`` Lambda is out of reach by construction.
+The default prefix (``aws-controltower-``) also does not match
+``enforce-log-retention``; do not broaden the prefix to a value
+that would tag the orchestrator itself.
 """
 
 import json
@@ -209,23 +223,86 @@ def _vanta_pass(
     return tagged
 
 
-def handler(event: dict[str, Any], context: Any) -> dict[str, int]:
-    """Scan log groups across all accounts and regions.
+def _vanta_lambda_pass(
+    account_id: str,
+    region: str,
+    role_name: str,
+    prefixes: list[str],
+    tag_value: str,
+) -> int:
+    """Tag Vanta-excluded Lambda functions in one account+region.
 
-    Runs the two passes in separate ThreadPoolExecutor phases so a
+    Mirrors :func:`_vanta_pass` but operates on Lambda functions.
+    Skips any function that already carries the ``VantaNoAlert``
+    key with any value — Vanta only checks key presence, so any
+    pre-existing value is honored and never overwritten.
+
+    The assumed role must have ``lambda:ListFunctions``,
+    ``lambda:ListTags``, and ``lambda:TagResource``.
+
+    :param account_id: 12-digit AWS account ID.
+    :type account_id: str
+    :param region: AWS region name.
+    :type region: str
+    :param role_name: IAM role name to assume in the target account.
+    :type role_name: str
+    :param prefixes: Lambda function name prefixes to match.
+    :type prefixes: list[str]
+    :param tag_value: Value to write for new VantaNoAlert tags.
+    :type tag_value: str
+    :return: Number of Lambda functions tagged.
+    :rtype: int
+    """
+    if not prefixes:
+        return 0
+    session = get_session(
+        role_arn=f"arn:aws:iam::{account_id}:role/{role_name}",
+        region=region,
+        session_name="enforce-vanta-lambda-tags",
+    )
+    lam = session.client("lambda")
+    tagged = 0
+    paginator = lam.get_paginator("list_functions")
+    for page in paginator.paginate():
+        for fn in page["Functions"]:
+            name = fn["FunctionName"]
+            if not any(name.startswith(p) for p in prefixes):
+                continue
+            arn = fn["FunctionArn"]
+            existing = lam.list_tags(Resource=arn).get("Tags", {})
+            if VANTA_EXCLUDE_TAG_KEY in existing:
+                continue
+            lam.tag_resource(Resource=arn, Tags={VANTA_EXCLUDE_TAG_KEY: tag_value})
+            LOG.info(
+                "Account %s %s: tagged Lambda %s with %s=%s",
+                account_id,
+                region,
+                name,
+                VANTA_EXCLUDE_TAG_KEY,
+                tag_value,
+            )
+            tagged += 1
+    return tagged
+
+
+def handler(event: dict[str, Any], context: Any) -> dict[str, int]:
+    """Scan log groups and Lambda functions across all accounts and regions.
+
+    Runs the three passes in separate ThreadPoolExecutor phases so a
     failure in one cannot cancel pending work in the other. Retention
     is the compliance-critical path and keeps fail-fast semantics;
     Vanta tagging is cosmetic (it only hides false positives in
     Vanta's alert feed) and runs best-effort — per-worker exceptions
     are logged and counted, but do not halt the phase. After all
-    workers finish, if any vanta errors occurred, the handler raises
-    ``RuntimeError`` so the Lambda reports failure.
+    workers finish, if any vanta errors occurred (in either tagging
+    phase), the handler raises ``RuntimeError`` so the Lambda
+    reports failure.
 
     :param event: Lambda event payload (unused).
     :type event: dict[str, Any]
     :param context: Lambda runtime context.
     :type context: Any
-    :return: Counts of updated, tagged, and errored log groups.
+    :return: Counts of updated, tagged, and errored resources.
     :rtype: dict[str, int]
     :raises RuntimeError: If any Vanta tagging errors occurred.
     """
@@ -238,11 +315,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, int]:
     ]
     missing = [v for v in required_vars if v not in os.environ]
     if missing:
-        raise RuntimeError(f"Required environment variable(s) not set: {', '.join(missing)}")
+        raise RuntimeError(
+            f"Required environment variable(s) not set: {', '.join(missing)}"
+        )
 
     retention_days = int(os.environ["RETENTION_DAYS"])
     retention_prefixes = json.loads(os.environ["LOG_GROUP_PREFIXES"])
     vanta_exclude_prefixes = json.loads(os.environ.get("VANTA_EXCLUDE_PREFIXES", "[]"))
+    vanta_exclude_lambda_prefixes = json.loads(
+        os.environ.get("VANTA_EXCLUDE_LAMBDA_PREFIXES", "[]")
+    )
     vanta_tag_value = os.environ["VANTA_EXCLUDE_TAG_VALUE"]
     role_name = os.environ["ASSUME_ROLE_NAME"]
     home_region = os.environ["CONTROL_TOWER_HOME_REGION"]
@@ -299,9 +381,9 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, int]:
                     f.cancel()
                 raise
 
-    # Phase 2: Vanta tagging — best-effort per worker. Individual
-    # failures don't abort remaining workers, but any errors cause
-    # the handler to raise after all workers finish.
+    # Phase 2: Vanta log-group tagging — best-effort per worker.
+    # Individual failures don't abort remaining workers, but any
+    # errors cause the handler to raise after all workers finish.
     total_tagged = 0
     vanta_errors = 0
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -328,20 +410,53 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, int]:
                 )
                 vanta_errors += 1
 
+    # Phase 3: Vanta Lambda-function tagging — same best-effort
+    # semantics as Phase 2.
+    total_tagged_lambdas = 0
+    vanta_lambda_errors = 0
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {
+            executor.submit(
+                _vanta_lambda_pass,
+                account_id,
+                region,
+                role_name,
+                vanta_exclude_lambda_prefixes,
+                vanta_tag_value,
+            ): (account_id, region)
+            for account_id, region in targets
+        }
+        for future in as_completed(futures):
+            account_id, region = futures[future]
+            try:
+                total_tagged_lambdas += future.result()
+            except ClientError:
+                LOG.exception(
+                    "Vanta Lambda tagging failed for account %s region %s",
+                    account_id,
+                    region,
+                )
+                vanta_lambda_errors += 1
+
+    total_vanta_errors = vanta_errors + vanta_lambda_errors
     LOG.info(
-        "Done. Updated %d log group(s), tagged %d for Vanta exclusion "
-        "(%d vanta errors).",
+        "Done. Updated %d log group(s), tagged %d log group(s) and "
+        "%d Lambda function(s) for Vanta exclusion (%d vanta errors).",
         total_updated,
         total_tagged,
-        vanta_errors,
+        total_tagged_lambdas,
+        total_vanta_errors,
     )
-    if vanta_errors:
+    if total_vanta_errors:
         raise RuntimeError(
-            f"Vanta tagging encountered {vanta_errors} error(s). "
-            f"Tagged {total_tagged} log group(s), updated retention on {total_updated}."
+            f"Vanta tagging encountered {total_vanta_errors} error(s) "
+            f"({vanta_errors} on log groups, {vanta_lambda_errors} on Lambdas). "
+            f"Tagged {total_tagged} log group(s), {total_tagged_lambdas} Lambda(s), "
+            f"updated retention on {total_updated}."
         )
     return {
         "updated": total_updated,
-        "tagged": total_tagged,
-        "vanta_errors": vanta_errors,
+        "tagged_log_groups": total_tagged,
+        "tagged_lambdas": total_tagged_lambdas,
+        "vanta_errors": total_vanta_errors,
     }

--- a/test_data/org-governance/main.tf
+++ b/test_data/org-governance/main.tf
@@ -12,7 +12,7 @@ module "org_governance" {
   # Test relies on AWSControlTowerExecution, which already exists in
   # every member account and (in this test org) trusts the Lambda's
   # execution role. Real users should stick with the default
-  # InfraHouseLogRetention role provisioned by terraform-aws-iso27001.
+  # InfraHouseGovernance role provisioned by terraform-aws-iso27001.
   enforce_log_retention_role_name = "AWSControlTowerExecution"
   # Exercise the retention pass with a synthetic prefix the test
   # owns. Default is empty since real retention enforcement is

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,11 +1,15 @@
+import io
 import json
 import random
+import time
+import zipfile
 from os import path as osp, remove
 from shutil import rmtree
 from textwrap import dedent
 
 import botocore.config
 import pytest
+from botocore.exceptions import ClientError
 from infrahouse_core.aws import get_session
 from infrahouse_core.aws.cloudwatch_log_group import CloudWatchLogGroup
 from pytest_infrahouse import terraform_apply
@@ -18,6 +22,9 @@ from tests.conftest import (
 TEST_RETENTION_LOG_GROUP = "/test/retention/enforce-test"
 TEST_VANTA_LOG_GROUP = "/aws/lambda/aws-controltower-test-retention"
 VANTA_NO_ALERT_TAG = "VantaNoAlert"
+LAMBDA_BASIC_EXEC_POLICY_ARN = (
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+)
 
 # Valid CloudWatch retention values excluding 365 (the usual default)
 VALID_RETENTION_DAYS = [
@@ -43,6 +50,96 @@ VALID_RETENTION_DAYS = [
     3288,
     3653,
 ]
+
+
+def _build_minimal_lambda_zip() -> bytes:
+    """Return a zip with a no-op Python handler suitable for create_function."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("handler.py", "def handler(event, context):\n    return {}\n")
+    return buf.getvalue()
+
+
+def _create_test_lambda(ct_session, function_name: str) -> dict:
+    """Create a synthetic Lambda function in the member account.
+
+    Returns a dict with the resources to clean up, suitable to pass
+    to :func:`_destroy_test_lambda`.
+    """
+    iam = ct_session.client("iam")
+    lam = ct_session.client("lambda")
+    role_name = f"{function_name}-exec"
+    trust_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
+    iam.create_role(
+        RoleName=role_name,
+        AssumeRolePolicyDocument=trust_policy,
+        Description="Temporary role for terraform-aws-org-governance test",
+    )
+    iam.attach_role_policy(
+        RoleName=role_name,
+        PolicyArn=LAMBDA_BASIC_EXEC_POLICY_ARN,
+    )
+    role_arn = iam.get_role(RoleName=role_name)["Role"]["Arn"]
+    # IAM role propagation to Lambda — empirically ~10s; retry with
+    # backoff to avoid flakes.
+    zip_bytes = _build_minimal_lambda_zip()
+    last_err = None
+    for attempt in range(6):
+        try:
+            lam.create_function(
+                FunctionName=function_name,
+                Runtime="python3.12",
+                Role=role_arn,
+                Handler="handler.handler",
+                Code={"ZipFile": zip_bytes},
+                PackageType="Zip",
+                Timeout=3,
+            )
+            break
+        except ClientError as err:
+            if err.response["Error"]["Code"] != "InvalidParameterValueException":
+                raise
+            last_err = err
+            time.sleep(5 * (attempt + 1))
+    else:
+        raise RuntimeError(
+            f"Lambda did not see role {role_arn} after retries: {last_err}"
+        )
+    return {"role_name": role_name, "function_name": function_name}
+
+
+def _destroy_test_lambda(ct_session, resources: dict) -> None:
+    iam = ct_session.client("iam")
+    lam = ct_session.client("lambda")
+    try:
+        lam.delete_function(FunctionName=resources["function_name"])
+    except ClientError as err:
+        if err.response["Error"]["Code"] != "ResourceNotFoundException":
+            LOG.warning("Failed to delete Lambda: %s", err)
+    try:
+        iam.detach_role_policy(
+            RoleName=resources["role_name"],
+            PolicyArn=LAMBDA_BASIC_EXEC_POLICY_ARN,
+        )
+    except ClientError as err:
+        if err.response["Error"]["Code"] != "NoSuchEntity":
+            LOG.warning("Failed to detach role policy: %s", err)
+    try:
+        iam.delete_role(RoleName=resources["role_name"])
+    except ClientError as err:
+        if err.response["Error"]["Code"] != "NoSuchEntity":
+            LOG.warning("Failed to delete role: %s", err)
 
 
 @pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
@@ -148,6 +245,12 @@ def test_module(
             logGroupName=TEST_VANTA_LOG_GROUP,
             retentionInDays=initial_retention,
         )
+        # Synthetic Lambda matching vanta_exclude_lambda_prefixes
+        # default (``aws-controltower-``). The Vanta Lambda pass must
+        # tag this function with VantaNoAlert.
+        test_lambda_name = f"aws-controltower-test-vanta-{random.randint(10000, 99999)}"
+        lambda_resources = _create_test_lambda(ct_session, test_lambda_name)
+        ct_lambda = ct_session.client("lambda")
         try:
             retention_lg = CloudWatchLogGroup(
                 TEST_RETENTION_LOG_GROUP, session=ct_session
@@ -197,8 +300,27 @@ def test_module(
                 vanta_lg.tags[VANTA_NO_ALERT_TAG],
                 vanta_lg.retention_in_days,
             )
+
+            # Vanta Lambda pass: tagged the synthetic Lambda matching
+            # the aws-controltower- prefix.
+            fn_arn = ct_lambda.get_function(FunctionName=test_lambda_name)[
+                "Configuration"
+            ]["FunctionArn"]
+            fn_tags = ct_lambda.list_tags(Resource=fn_arn).get("Tags", {})
+            assert VANTA_NO_ALERT_TAG in fn_tags, (
+                f"Expected {VANTA_NO_ALERT_TAG} on {test_lambda_name}, "
+                f"got tags: {fn_tags}"
+            )
+            LOG.info(
+                "After vanta lambda pass: %s has tag %s=%s",
+                test_lambda_name,
+                VANTA_NO_ALERT_TAG,
+                fn_tags[VANTA_NO_ALERT_TAG],
+            )
         finally:
             LOG.info("Cleaning up %s", TEST_RETENTION_LOG_GROUP)
             ct_logs.delete_log_group(logGroupName=TEST_RETENTION_LOG_GROUP)
             LOG.info("Cleaning up %s", TEST_VANTA_LOG_GROUP)
             ct_logs.delete_log_group(logGroupName=TEST_VANTA_LOG_GROUP)
+            LOG.info("Cleaning up Lambda %s", test_lambda_name)
+            _destroy_test_lambda(ct_session, lambda_resources)

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,25 @@ variable "vanta_exclude_prefixes" {
   ]
 }
 
+variable "vanta_exclude_lambda_prefixes" {
+  description = <<-EOT
+    Lambda function name prefixes to tag with VantaNoAlert=true,
+    marking them out of scope for Vanta compliance tests. Use this
+    for Lambdas where Vanta findings (e.g., "Serverless function
+    error rate monitored (AWS)") cannot be remediated because the
+    Lambda is managed by AWS itself — Control Tower deploys
+    aws-controltower-NotificationForwarder into every governed
+    account/region and we cannot add CloudWatch alarms without
+    StackSet drift. Vanta honors the VantaNoAlert tag continuously
+    via its AWS integration. Applying is idempotent — already-
+    tagged functions are skipped.
+  EOT
+  type        = list(string)
+  default = [
+    "aws-controltower-",
+  ]
+}
+
 variable "vanta_exclude_tag_value" {
   description = <<-EOT
     Value to write for the VantaNoAlert tag on newly tagged log groups.
@@ -101,13 +120,17 @@ variable "vanta_exclude_tag_value" {
 variable "enforce_log_retention_role_name" {
   description = <<-EOT
     Name of the cross-account IAM role the Lambda assumes in each
-    member account to enforce log retention. The role must exist in
-    every scanned account and trust the management account root.
-    Defaults to InfraHouseLogRetention, provisioned by
-    terraform-aws-iso27001.
+    member account. The role must exist in every scanned account
+    and trust the management account root. Defaults to
+    InfraHouseGovernance (provisioned by terraform-aws-iso27001
+    >= 2.2.0), which carries permissions for both log-group
+    retention/tagging and Lambda function tagging. The variable
+    name retains the historical "log_retention" prefix; the role
+    is now the broader governance role and a future release will
+    rename the variable accordingly.
   EOT
   type        = string
-  default     = "InfraHouseLogRetention"
+  default     = "InfraHouseGovernance"
 }
 
 variable "control_tower_home_region" {


### PR DESCRIPTION
Closes #8.

## Summary

- Adds a third pass to `enforce-log-retention` Lambda that tags member-account Lambda functions matching `var.vanta_exclude_lambda_prefixes` (default `["aws-controltower-"]`) with `VantaNoAlert=true`, mirroring the existing log-group tagging pass. Closes the loop on the 44 `aws-controltower-NotificationForwarder` Vanta findings.
- Switches the cross-account role default from `InfraHouseLogRetention` to `InfraHouseGovernance` (provisioned by `terraform-aws-iso27001` >= 2.2.0), which adds `lambda:ListFunctions` / `lambda:ListTags` / `lambda:TagResource`. Variable name `enforce_log_retention_role_name` is unchanged for backward compatibility (option (a) from the issue).
- Phase 3 uses the same best-effort error semantics as Phase 2 — per-(account, region) failures are logged and counted; the handler raises `RuntimeError` at the end if any vanta errors occurred (across either tagging phase).
- Return dict now reports `tagged_log_groups`, `tagged_lambdas`, and a combined `vanta_errors`.
- Tag-presence check (not value equality), so operator-set values are preserved.
- Paginated `lambda:ListFunctions` to handle audit/log-archive accounts with hundreds of functions.
- Module-level docstring documents that the management account is never assumed into and the default prefix does not match `enforce-log-retention`, so the orchestrator is out of reach by construction.

## Test plan

- [ ] `make test-clean` passes — integration test now also creates a synthetic `aws-controltower-test-vanta-{nnnn}` Lambda + IAM role in the member account via `AWSControlTowerExecution`, runs the management Lambda, and asserts `VantaNoAlert` is set.
- [ ] After deploy, manually invoke: `aws lambda invoke --function-name enforce-log-retention --payload '{}' /tmp/out.json` and inspect counts.
- [ ] Spot-check: `aws lambda list-tags --resource arn:aws:lambda:us-west-1:<acct>:function:aws-controltower-NotificationForwarder` shows `VantaNoAlert`.
- [ ] After one Vanta sync (~1h), confirm the 44 `aws-controltower-NotificationForwarder` entities drop out of `serverless-function-error-rate-monitored-aws`.

## Notes

- File `cloudwatch_log_retention.tf` is intentionally not renamed (per issue's deferred recommendation).
- README's terraform-docs section was edited manually; pre-commit `terraform-docs` will reconcile on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)