### PR TITLE
fix: use String type for SSM parameter in CloudFormation StackSet

### DIFF
--- a/vanta.tf
+++ b/vanta.tf
@@ -45,14 +45,14 @@ resource "aws_cloudformation_stack_set" "vanta_external_id" {
     AWSTemplateFormatVersion = "2010-09-09"
     Description              = "SSM parameter for Vanta external ID, managed by terraform-aws-org-governance"
     Parameters = {
-      ExternalId = { Type = "String", NoEcho = true }
+      ExternalId = { Type = "String" }
     }
     Resources = {
       VantaExternalId = {
         Type = "AWS::SSM::Parameter"
         Properties = {
           Name  = "/vanta/external_id"
-          Type  = "SecureString"
+          Type  = "String"
           Value = { Ref = "ExternalId" }
         }
       }


### PR DESCRIPTION
## Summary
- CloudFormation's `AWS::SSM::Parameter` does not support `SecureString` as a type enum — only `String` and `StringList`. This caused StackSet deployment to fail in all member accounts.
- Removes `NoEcho` from the CF template parameter to prevent perpetual Terraform diff (`DescribeStackSet` returns `****`, triggering an update every plan).

Closes #13

## Test plan
- [ ] `terraform plan` shows template_body update (type change + NoEcho removal)
- [ ] `terraform apply` succeeds
- [ ] StackSet instances deploy successfully to member accounts
- [ ] Subsequent `terraform plan` shows no diff (NoEcho fix verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)