### PR TITLE
fix: tolerate deleted buckets in Vanta S3 CRR reconciler

### DIFF
--- a/modules/vanta_exemption/s3_crr/lambda/handler.py
+++ b/modules/vanta_exemption/s3_crr/lambda/handler.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 import boto3
 import requests
+from botocore.exceptions import ClientError
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -113,10 +114,16 @@ def _get_bucket_tag(bucket_name: str, session: boto3.Session) -> Optional[str]:
     :type bucket_name: str
     :param session: Boto3 session with credentials for the bucket's account.
     :type session: boto3.Session
-    :return: Tag value if present, None otherwise.
+    :return: Tag value if present, None otherwise. A deleted bucket
+        (``NoSuchBucket``) is treated as having no exemption tag.
     :rtype: Optional[str]
     """
-    return S3Bucket(bucket_name, session=session).tags.get(TAG_KEY)
+    try:
+        return S3Bucket(bucket_name, session=session).tags.get(TAG_KEY)
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "NoSuchBucket":
+            return None
+        raise
 
 
 def handler(event: dict, context: object) -> dict:
@@ -211,6 +218,8 @@ def handler(event: dict, context: object) -> dict:
         for bucket_name, entity_id in deactivated_by_account.get(
             account_id, []
         ):
+            # A deleted bucket reports no tag, so the stale managed-deactivated
+            # entity is reactivated here and drains out on the next run.
             tag_value = _get_bucket_tag(bucket_name, session)
             if tag_value is None:
                 http.post(


### PR DESCRIPTION
## Summary

Fixes #18 — a deleted bucket that is still tracked as a Vanta entity no longer aborts the entire reconcile run.

When a managed-deactivated bucket was deleted in AWS but still existed as a `DEACTIVATED` Vanta entity, the Phase 3 drift-correction loop called `GetBucketTagging` and threw an unhandled `NoSuchBucket`, killing the whole run. No other buckets got reconciled until the stale Vanta entity was removed by hand.

## Fix

`_get_bucket_tag` now catches `NoSuchBucket` and treats a gone bucket as "no exemption tag" (returns `None`). Any other `ClientError` still propagates.

This fixes both call sites:
- **Phase 2 (failing entities):** gone bucket → `None` → skipped, no deactivate.
- **Phase 3 (managed-deactivated):** gone bucket → `None` → existing logic reactivates the entity, so the stale entry self-heals and drains out of the deactivated set on the next run.

`NoSuchTagSet` (bucket exists, no tags) remains handled inside `infrahouse_core` `S3Bucket.tags` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)