### PR TITLE
fix: bump lambda-monitored to 1.1.1 to exempt lambda buckets in Vanta

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Full documentation is available on
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_enforce_log_retention"></a> [enforce\_log\_retention](#module\_enforce\_log\_retention) | registry.infrahouse.com/infrahouse/lambda-monitored/aws | 1.1.0 |
+| <a name="module_enforce_log_retention"></a> [enforce\_log\_retention](#module\_enforce\_log\_retention) | registry.infrahouse.com/infrahouse/lambda-monitored/aws | 1.1.1 |
 | <a name="module_vanta_s3_crr"></a> [vanta\_s3\_crr](#module\_vanta\_s3\_crr) | ./modules/vanta_exemption/s3_crr | n/a |
 
 ## Resources

--- a/cloudwatch_log_retention.tf
+++ b/cloudwatch_log_retention.tf
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "enforce_log_retention" {
 module "enforce_log_retention" {
   count   = var.enforce_log_retention ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.1.0"
+  version = "1.1.1"
 
   function_name     = "enforce-log-retention"
   lambda_source_dir = "${path.module}/lambda/enforce_log_retention"

--- a/modules/vanta_exemption/s3_crr/main.tf
+++ b/modules/vanta_exemption/s3_crr/main.tf
@@ -27,7 +27,7 @@ resource "aws_iam_policy" "this" {
 
 module "lambda" {
   source  = "registry.infrahouse.com/infrahouse/lambda-monitored/aws"
-  version = "1.1.0"
+  version = "1.1.1"
 
   function_name     = "vanta-s3-crr-reconciler"
   lambda_source_dir = "${path.module}/lambda"


### PR DESCRIPTION
## Summary

Bumps the `lambda-monitored/aws` module from `1.1.0` to `1.1.1` at both call sites:
- `cloudwatch_log_retention.tf` (`enforce-log-retention`)
- `modules/vanta_exemption/s3_crr/main.tf` (`vanta-s3-crr-reconciler`)

`1.1.1` upgrades the module's internal `s3-bucket` dependency to `0.6.0` and tags the Lambda deployment-package bucket with:

```
vanta-exempt:aws-s3-cross-region-replication-enabled = "Lambda deployment artifact bucket - ephemeral build output. No DR value"
```

So the ephemeral build-artifact buckets are exempted from the S3 CRR test instead of showing up as failing/managed entities the reconciler has to chase. Complements #19, which made the reconciler tolerate these buckets once they're deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)